### PR TITLE
Adding a basic CRUD for Book Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ To build and run the application as a JAR file:
 
 ## API Endpoints
 
-| Method | Endpoint          | Description                   |
-|--------|-------------------|-------------------------------|
-| GET    | `/books`           | Retrieve all books            |
-| GET    | `/books/{id}`      | Retrieve a specific book      |
-| POST   | `/books`           | Create a new book             |
-| PUT    | `/books/{id}`      | Update an existing book       |
-| DELETE | `/books/{id}`      | Delete a book                 |
+| Method | Endpoint             | Description                   |
+|--------|----------------------|-------------------------------|
+| GET    | `/api/v1/books`      | Retrieve all books            |
+| GET    | `/api/v1/books/{id}` | Retrieve a specific book      |
+| POST   | `/api/v1/books`      | Create a new book             |
+| PUT    | `/api/v1/books/{id}` | Update an existing book       |
+| DELETE | `/api/v1/books/{id}` | Delete a book                 |
 
 ## Database
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -51,10 +52,31 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.6.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct-processor</artifactId>
+			<version>1.6.2</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.34</version>
+			<scope>provided</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -62,6 +84,30 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<annotationProcessorPaths>
+						<!-- Lombok Annotation Processor -->
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.34</version>
+						</path>
+						<!-- MapStruct Annotation Processor -->
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.6.2</version>
+						</path>
+					</annotationProcessorPaths>
+					<compilerArgs>
+						<compilerArg>-Amapstruct.defaultComponentModel=spring</compilerArg>
+					</compilerArgs>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/example/library/controller/BookController.java
+++ b/src/main/java/com/example/library/controller/BookController.java
@@ -1,0 +1,53 @@
+package com.example.library.controller;
+
+import com.example.library.dto.BookDTO;
+import com.example.library.service.BookService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/v1/books")
+public class BookController {
+
+    private final BookService bookService;
+
+    @Autowired
+    public BookController(BookService bookService) {
+        this.bookService = bookService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<BookDTO>> getBooks() {
+        return ResponseEntity.ok(bookService.getAllBooks());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BookDTO> getBookById(@PathVariable("id") Long id) {
+        return bookService.getBookById(id)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<BookDTO> createBook(@RequestBody BookDTO requestBody) {
+        BookDTO createdBook = bookService.createBook(requestBody);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdBook);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<BookDTO> updateBook(@RequestBody BookDTO requestBody, @PathVariable("id") Long id) {
+        return bookService.updateBook(id, requestBody)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteBook(@PathVariable("id") Long id) {
+        boolean isDeleted = bookService.deleteBookById(id);
+        return isDeleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/example/library/dto/BookDTO.java
+++ b/src/main/java/com/example/library/dto/BookDTO.java
@@ -1,0 +1,16 @@
+package com.example.library.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookDTO {
+    private Long id;
+    private String title;
+    private String author;
+    private String isbn;
+    private int publicationYear;
+}

--- a/src/main/java/com/example/library/entity/Book.java
+++ b/src/main/java/com/example/library/entity/Book.java
@@ -1,0 +1,23 @@
+package com.example.library.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Book {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String author;
+    private String isbn;
+    private int publicationYear;
+}

--- a/src/main/java/com/example/library/mapper/BookMapper.java
+++ b/src/main/java/com/example/library/mapper/BookMapper.java
@@ -1,0 +1,18 @@
+package com.example.library.mapper;
+
+import com.example.library.dto.BookDTO;
+import com.example.library.entity.Book;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface BookMapper {
+    BookMapper INSTANCE = Mappers.getMapper(BookMapper.class);
+
+    @Mapping(source = "id", target = "id")
+    BookDTO toBookDTO(Book book);
+
+    @Mapping(source = "id", target = "id")
+    Book toBookEntity(BookDTO bookDTO);
+}

--- a/src/main/java/com/example/library/repository/BookRepository.java
+++ b/src/main/java/com/example/library/repository/BookRepository.java
@@ -1,0 +1,7 @@
+package com.example.library.repository;
+
+import com.example.library.entity.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/src/main/java/com/example/library/service/BookService.java
+++ b/src/main/java/com/example/library/service/BookService.java
@@ -1,0 +1,14 @@
+package com.example.library.service;
+
+import com.example.library.dto.BookDTO;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BookService {
+    List<BookDTO> getAllBooks();
+    Optional<BookDTO> getBookById(Long id);
+    BookDTO createBook(BookDTO bookDTO);
+    Optional<BookDTO> updateBook(Long id, BookDTO bookDTO);
+    boolean deleteBookById(Long id);
+}

--- a/src/main/java/com/example/library/service/impl/BookServiceImpl.java
+++ b/src/main/java/com/example/library/service/impl/BookServiceImpl.java
@@ -1,0 +1,69 @@
+package com.example.library.service.impl;
+
+import com.example.library.dto.BookDTO;
+import com.example.library.entity.Book;
+import com.example.library.mapper.BookMapper;
+import com.example.library.repository.BookRepository;
+import com.example.library.service.BookService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class BookServiceImpl implements BookService {
+
+    private final BookRepository bookRepository;
+    private final BookMapper bookMapper;
+
+    @Autowired
+    public BookServiceImpl(BookRepository bookRepository, BookMapper bookMapper) {
+        this.bookRepository = bookRepository;
+        this.bookMapper = bookMapper;
+    }
+
+    @Override
+    public List<BookDTO> getAllBooks() {
+        List<Book> bookList = bookRepository.findAll();
+        return bookList.stream()
+                .map(bookMapper::toBookDTO)
+                .toList();
+    }
+
+    @Override
+    public Optional<BookDTO> getBookById(Long id) {
+        return bookRepository.findById(id)
+                .map(bookMapper::toBookDTO);
+    }
+
+    @Override
+    public BookDTO createBook(BookDTO bookDTO) {
+        Book book = bookMapper.toBookEntity(bookDTO);
+        Book savedBook = bookRepository.save(book);
+        return bookMapper.toBookDTO(savedBook);
+    }
+
+    @Override
+    public Optional<BookDTO> updateBook(Long id, BookDTO bookDTO) {
+        return bookRepository.findById(id)
+                .map(existingBook -> {
+                    existingBook.setAuthor(bookDTO.getAuthor());
+                    existingBook.setIsbn(bookDTO.getIsbn());
+                    existingBook.setTitle(bookDTO.getTitle());
+                    existingBook.setPublicationYear(bookDTO.getPublicationYear());
+                    Book updatedBook = bookRepository.save(existingBook);
+                    return bookMapper.toBookDTO(updatedBook);
+                });
+    }
+
+    @Override
+    public boolean deleteBookById(Long id) {
+        if (bookRepository.existsById(id)) {
+            bookRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,14 @@ spring.application.name=book-service
 
 #Actuator
 management.endpoints.web.exposure.include=health
+
+#Database configuration for H2
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.h2.console.enabled=true
+
+#JPA
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
This is the first CRUD version of Book Service. The README.md was updated with the correct endpoints and the unit tests will be implemented for the next sprint.


Result of the `man clean install` command locally:

<img width="564" alt="Screenshot 2024-10-25 at 10 08 09 AM" src="https://github.com/user-attachments/assets/f7aa8d54-5d3b-4194-83bf-dc24e2717a50">

The endpoints was tested with Bruno App (and alternative for the popular POSTMAN):

**Create**
<img width="1273" alt="Screenshot 2024-10-25 at 10 11 47 AM" src="https://github.com/user-attachments/assets/677ea8c2-5888-494c-b41e-7b0f94b03e3f">

**Get all books**
<img width="1279" alt="Screenshot 2024-10-25 at 10 12 47 AM" src="https://github.com/user-attachments/assets/4c8b0f1d-a0b6-4314-98db-f9f7488800f1">

**Get a book by Id**
<img width="1272" alt="Screenshot 2024-10-25 at 10 13 21 AM" src="https://github.com/user-attachments/assets/1f7b0fa3-a24a-4c3f-9fd5-33fc176608a2">

**Update a book**
<img width="1274" alt="Screenshot 2024-10-25 at 10 14 09 AM" src="https://github.com/user-attachments/assets/2176d938-cbf3-4eda-9878-74adb1e8c676">

**Delete a book**
<img width="1276" alt="Screenshot 2024-10-25 at 10 14 38 AM" src="https://github.com/user-attachments/assets/63759d2a-ab4c-4717-868d-68dadda79a27">





