### PR TITLE
Creación de job para ejecutar pruebas de unidad

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,10 @@ jobs:
           java-version: 21
 
       - name: Run test
-        run: mvn clean test jacoco:report
+        run: mvn clean test
 
       - name: Publish Test Report
         if: success() || failure()
-        uses: ScaCap/action-surefire-report@v1.8.0
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: target/surefire-reports/TEST-*.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
+    needs: build
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.1
@@ -38,20 +39,6 @@ jobs:
       - name: Run test
         run: mvn clean test jacoco:report
 
-      - name: Upload Surfire report
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: Surefire reports
-          path: target/surefire-reports/
-      
-      - name: Upload Jacoco report
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: Jacoco reports
-          path: target/site/jacoco
-
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
         if: success() || failure()
-        with:
-          report_paths: target/surefire-reports/TEST-*.xml
+        uses: ScaCap/action-surefire-report@v1.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,45 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.1
+      
       - name: Install maven and jdk
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: 21
+      
       - name: Build app
-        run: mvn clean install
-      - name: Validate compile object    
-        run: ls -l target/
+        run: mvn clean install -Dmaven.test.skip=true
 
-        
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.1
+      
+      - name: Install maven and jdk
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: 21
+
+      - name: Run test
+        run: mvn clean test jacoco:report
+
+      - name: Upload Surfire report
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: Surefire reports
+          path: target/surefire-reports/
+      
+      - name: Upload Jacoco report
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: Jacoco reports
+          path: target/site/jacoco
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure()
+        with:
+          report_paths: target/surefire-reports/TEST-*.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
 
       - name: Publish Test Report
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v4
+        uses: scacap/action-surefire-report@v1
         with:
-          report_paths: target/surefire-reports/TEST-*.xml
+          check_name: Unit test report
+          fail_on_test_failures: true
+          file_name_in_stack_trace: true
+          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     needs: build
+    permissions: 
+      checks: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Book Service
 
-![Estado de las pruebas](https://github.com/victorhtorres/book-service/actions/workflows/ci.yml/badge.svg?branch=unit-test-ci)
+![Estado de las pruebas](https://github.com/victorhtorres/book-service/actions/workflows/ci.yml/badge.svg?branch=main)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Book Service
 
+[![codecov](https://codecov.io/github/jacs4210/book-service/graph/badge.svg?token=FBHYV6VVZM)](https://codecov.io/github/jacs4210/book-service)
+
 ## Overview
 
 This is a Spring Boot microservice for managing book-related operations. It includes RESTful API endpoints for CRUD operations on book data, such as creating, updating, retrieving, and deleting book records.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Book Service
 
-[![codecov](https://codecov.io/github/jacs4210/book-service/graph/badge.svg?token=FBHYV6VVZM)](https://codecov.io/github/jacs4210/book-service)
+![Estado de las pruebas](https://github.com/jacs4210/book-service/actions/workflows/ci.yml/badge.svg?branch=unit-test-ci)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Book Service
 
-![Estado de las pruebas](https://github.com/jacs4210/book-service/actions/workflows/ci.yml/badge.svg?branch=unit-test-ci)
+![Estado de las pruebas](https://github.com/victorhtorres/book-service/actions/workflows/ci.yml/badge.svg?branch=unit-test-ci)
 
 ## Overview
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,27 +119,6 @@
 					<reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
 				</configuration>
 			</plugin>
-
-			<!-- Jacoco Plugin -->
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.12</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>report</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,37 @@
 					</compilerArgs>
 				</configuration>
 			</plugin>
+
+			<!-- Surefire Plugin -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.1.2</version>
+				<configuration>
+					<reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+				</configuration>
+			</plugin>
+
+			<!-- Jacoco Plugin -->
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Se crea JOB en el workflow ci.yml para ejecutar las pruebas de unidad del proyecto. Se adiciona la posibilidad de visualizar un resumen de las pruebas accediendo al workflow ejecutado en la opción de Actions del proyecto e ir al job **Unit test Report** y se visualizaría lo siguiente:

<img width="904" alt="image" src="https://github.com/user-attachments/assets/3f131c88-6320-4eec-ab1d-3b85e60e29ad">

Adicionalmente, se añade badge en el readme del proyecto para que se visualice el estado del ultimo Pipeline lanzado sobre la rama main.

<img width="182" alt="image" src="https://github.com/user-attachments/assets/e7e6d5e7-401f-4669-8011-84e3a559a60d">
