### PR TITLE
Added JaCoCo plugin and a coverage with at least of 80%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<jacoco.version>0.8.12</jacoco.version>
+		<coverage.minimum>0.80</coverage.minimum>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -121,5 +123,74 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>coverage-check</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco.version}</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>report</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>check</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>check</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<rule>
+											<element>BUNDLE</element>
+											<limits>
+												<limit>
+													<counter>INSTRUCTION</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>${coverage.minimum}</minimum>
+												</limit>
+												<limit>
+													<counter>LINE</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>${coverage.minimum}</minimum>
+												</limit>
+												<limit>
+													<counter>BRANCH</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>${coverage.minimum}</minimum>
+												</limit>
+											</limits>
+										</rule>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+						<configuration>
+							<excludes>
+								<!-- Exclude MapStruct interfaces -->
+								<exclude>**/mapper/**</exclude>
+								<!-- Exclude MapStruct generated implementation classes -->
+								<exclude>**/*MapperImpl.class</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 
 </project>


### PR DESCRIPTION
- Added JaCoCo plugin in the pom.xm
- To run the units testing and coverage verification, run the following command: `mvn verify -Pcoverage-check`
- The `coverage-check` is a new profile configured with the idea to run the coverage verification. If you omit that parameter, then the coverage will be omitted in the `mvn verify` command.

Example:

<img width="1259" alt="Screenshot 2024-11-27 at 4 55 06 PM" src="https://github.com/user-attachments/assets/ae24d0f8-cdf7-47c8-83c5-8c23be123f8a">

You can validate the report generated in the following path: `target/site/jacoco/index.html` and looks as the following example:

<img width="1263" alt="Screenshot 2024-11-27 at 4 56 22 PM" src="https://github.com/user-attachments/assets/065a8745-efe4-4d78-a7d9-db155f3a5059">
