### PR TITLE
(Upd) Se ajusta el comando utilizado para ejecutar las pruebas de unidad

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           java-version: 21
 
       - name: Run test
-        run: mvn clean test
+        run: mvn verify -Pcoverage-check
 
       - name: Publish Test Report
         if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: mvn verify -Pcoverage-check
 
       - name: Publish Test Report
-        if: success() || failure()
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: scacap/action-surefire-report@v1
         with:
           check_name: Unit test report


### PR DESCRIPTION
Se justa el job **test** para que el comando a ejecutar sea `mvn verify -Pcoverage-check` el cual es el sugerido de acuerdo  a la implementación realizada en el PR #6